### PR TITLE
Add the TypeNameParser preparing improvements to the TypeName struct

### DIFF
--- a/Package.resolved.license
+++ b/Package.resolved.license
@@ -1,0 +1,6 @@
+
+This source file is part of the Apodini open source project
+
+SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+
+SPDX-License-Identifier: MIT

--- a/Sources/ApodiniTypeInformation/Utilities/TypeNameParser.swift
+++ b/Sources/ApodiniTypeInformation/Utilities/TypeNameParser.swift
@@ -1,0 +1,143 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+typealias ParsedTypeName = [ParsedTypeNamePart]
+
+enum ParsedTypeNamePart: Hashable {
+    case targetName(name: String)
+    indirect case typeName(name: String, generics: [ParsedTypeName] = [])
+}
+
+class TypeNameParser {
+    enum State {
+        case targetName
+        case typeName
+        case parsingGeneric
+    }
+
+    /// The input to the parser!
+    private let input: String
+    /// The current index to the character which we are parsing.
+    private var index: String.Index
+
+    /// The current parser state.
+    private var state: State = .targetName
+
+    /// Used to store all characters of a type name or target name while parsing.
+    private var typeNameOutput: [Character] = []
+    /// Used to store all characters of a generic argument while parsing input.
+    /// The resulting string is used as the input for another ``TypeNameParser`` parser.
+    private var subParserInput: [Character] = []
+    /// Collects all the results of an instantiated sub ``TypeNameParser``.
+    /// Those collect the ``ParsedTypeName`` of all the generic arguments of the currently parsed type name.
+    private var genericOutput: [ParsedTypeName] = []
+
+    /// Captures the current generic argument parsing depth.
+    /// Property is incremented for every `<` encountered, and decremeneted for every `>` encountered.
+    private var genericParsingDepth = 0
+
+    /// Consecutively stores the result of the parser.
+    private var result: ParsedTypeName = []
+
+    var hasRemainingInput: Bool {
+        self.index < input.endIndex
+    }
+
+    init(_ input: String) {
+        self.input = input.replacingOccurrences(of: " ", with: "")
+        self.index = input.startIndex
+    }
+
+    func parse() -> ParsedTypeName {
+        while hasRemainingInput {
+            let next = input[index]
+            self.index = input.index(after: self.index)
+            handle(next: next)
+        }
+
+        return result
+    }
+
+    func handle(next character: Character) {
+        switch state {
+        case .targetName:
+            handlePackageName(character: character)
+        case .typeName:
+            handleTypeName(character: character)
+        case .parsingGeneric:
+            handleGeneric(character: character)
+        }
+    }
+
+    private func handlePackageName(character: Character) {
+        if character == "." || !hasRemainingInput {
+            result.append(.targetName(name: String(typeNameOutput)))
+            typeNameOutput.removeAll()
+
+            state = .typeName
+        } else {
+            typeNameOutput.append(character)
+        }
+    }
+
+    private func handleTypeName(character: Character) {
+        if character == "." {
+            finishUpTypeName()
+        } else if character == "<" {
+            genericParsingDepth += 1
+            state = .parsingGeneric
+        } else {
+            typeNameOutput.append(character)
+
+            if !hasRemainingInput {
+                finishUpTypeName()
+            }
+        }
+    }
+
+    private func handleGeneric(character: Character) {
+        if (character == "," || character == ">") && genericParsingDepth == 1 {
+            // we only consider "," and ">" if they appear on level 1,
+            // otherwise they are part of the current generic argument parsed, and are treated in the else branch
+
+            let genericArgument = String(subParserInput)
+            subParserInput.removeAll()
+
+            // feed the argument into a sub parser instance to parse the type name.
+            let result = TypeNameParser(genericArgument).parse()
+            genericOutput.append(result)
+
+            if character == ">" {
+                genericParsingDepth -= 1
+                state = .typeName
+
+                if !hasRemainingInput {
+                    finishUpTypeName()
+                }
+            }
+        } else {
+            // update the genericParsingDepth counter
+            if character == "<" {
+                genericParsingDepth += 1
+            } else if character == ">" {
+                genericParsingDepth -= 1
+            }
+
+            subParserInput.append(character)
+        }
+    }
+
+    private func finishUpTypeName() {
+        result.append(.typeName(name: String(typeNameOutput), generics: genericOutput))
+
+        typeNameOutput.removeAll()
+        genericOutput.removeAll()
+    }
+}

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -1,0 +1,79 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+@testable import ApodiniTypeInformation
+
+final class TypeNameParserTests: TypeInformationTestCase {
+    func testSimpleType() {
+        XCTAssertEqual(
+            TypeNameParser("SomeTarget.TestType1.TestType2").parse(),
+            [
+                .targetName(name: "SomeTarget"),
+                .typeName(name: "TestType1"),
+                .typeName(name: "TestType2")
+            ]
+        )
+    }
+
+    func testGenericType() {
+        XCTAssertEqual(
+            TypeNameParser("ApodiniMigratorTests.TestTypes.Generic<ApodiniMigratorTests.Queue, Swift.String>").parse(),
+            [
+                .targetName(name: "ApodiniMigratorTests"),
+                .typeName(name: "TestTypes"),
+                .typeName(name: "Generic", generics: [
+                    [
+                        .targetName(name: "ApodiniMigratorTests"),
+                        .typeName(name: "Queue")
+                    ],
+                    [
+                        .targetName(name: "Swift"),
+                        .typeName(name: "String")
+                    ]
+                ])
+            ]
+        )
+    }
+
+    func testMultipleGenerics() {
+        XCTAssertEqual(
+            // swiftlint:disable:next line_length
+            TypeNameParser("TargetName.SomeType<TargetName.Generic<Swift.String, Swift.Int>>.SomeNestedType<TargetName.SomeOtherType, TargetName.Type2>")
+                .parse(),
+            [
+                .targetName(name: "TargetName"),
+                .typeName(name: "SomeType", generics: [
+                    [
+                        .targetName(name: "TargetName"),
+                        .typeName(name: "Generic", generics: [
+                            [
+                                .targetName(name: "Swift"),
+                                .typeName(name: "String")
+                            ],
+                            [
+                                .targetName(name: "Swift"),
+                                .typeName(name: "Int")
+                            ]
+                        ])
+                    ]
+                ]),
+                .typeName(name: "SomeNestedType", generics: [
+                    [
+                        .targetName(name: "TargetName"),
+                        .typeName(name: "SomeOtherType")
+                    ],
+                    [
+                        .targetName(name: "TargetName"),
+                        .typeName(name: "Type2")
+                    ]
+                ])
+            ]
+        )
+    }
+}


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2021 Paul Schmiedmayer and the project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add the TypeNameParser preparing improvements to the TypeName struct

## :recycle: Current situation & Problem

Currently, the `TypeName` doesn't consider generic arguments when parsing the type name from `String(reflecting:)`.

## :bulb: Proposed solution

This PR is step one to solving this, by introducing a parser which is capable of parsing type names and their potentially nested generic arguments. This Parser will be integrated in a follow up PR into the `TypeName` struct.

## :heavy_plus_sign: Additional Information

### Related PRs
-- 

### Testing
Additional testing was added.

### Reviewer Nudging
-- 