### PR TITLE
Add support for declaring and parsing Metadata in the TypeInformation framework

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -325,6 +325,7 @@ only_rules:
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - .build
   - .swiftpm
+  - .xcodebuild
 
 closure_body_length: # Closure bodies should not span too many lines.
   - 35 # warning - default: 20

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "AssociatedTypeRequirementsKit",
+        "repositoryURL": "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git",
+        "state": {
+          "branch": null,
+          "revision": "2e4c49c21ffb2135f1c99fbfcf2119c9d24f5e8c",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "package": "MetadataSystem",
+        "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
+        "state": {
+          "branch": null,
+          "revision": "5c5b7f0a01017785e3d265fa5d04f0e0b5b3a733",
+          "version": "0.1.0"
+        }
+      },
+      {
         "package": "Runtime",
         "repositoryURL": "https://github.com/Supereg/Runtime.git",
         "state": {

--- a/Package.resolved.license
+++ b/Package.resolved.license
@@ -1,0 +1,6 @@
+
+This source file is part of the Apodini open source project
+
+SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+
+SPDX-License-Identifier: MIT

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 //
 // This source file is part of the Apodini open source project
@@ -17,37 +17,48 @@ enum RuntimeDependency {
     case fork
     /// The regular upstream package
     case standard
+}
 
-    var dependency: Package.Dependency {
-        switch self {
-        case .enumSupport:
-            return .package(url: "https://github.com/PSchmiedmayer/Runtime.git", .revision("b810847a466ecd1cf65e7f39e6e715734fdc672c"))
-        case .fork:
-            return .package(url: "https://github.com/Supereg/Runtime.git", from: "2.2.3")
-        case .standard:
-            return .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.2")
-        }
+func runtimeDependency(selecting dependency: RuntimeDependency) -> Package.Dependency {
+    switch dependency {
+    case .enumSupport:
+        return .package(url: "https://github.com/PSchmiedmayer/Runtime.git", .revision("b810847a466ecd1cf65e7f39e6e715734fdc672c"))
+    case .fork:
+        return .package(url: "https://github.com/Supereg/Runtime.git", from: "2.2.3")
+    case .standard:
+        return .package(url: "https://github.com/wickwirew/Runtime.git", from: "2.2.2")
     }
 }
 
 let package = Package(
     name: "ApodiniTypeInformation",
     platforms: [
-        .macOS(.v10_15)
+        .macOS(.v12)
     ],
     products: [
-        .library(name: "ApodiniTypeInformation", targets: ["ApodiniTypeInformation"])
+        .library(name: "ApodiniTypeInformation", targets: ["ApodiniTypeInformation"]),
+        .library(name: "TypeInformationMetadata", targets: ["TypeInformationMetadata"])
     ],
     dependencies: [
-        RuntimeDependency.fork.dependency
+        runtimeDependency(selecting: .fork),
+        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.0"))
     ],
     targets: [
         .target(
             name: "ApodiniTypeInformation",
             dependencies: [
-                .product(name: "Runtime", package: "Runtime")
+                .product(name: "Runtime", package: "Runtime"),
+                .target(name: "TypeInformationMetadata")
             ]
         ),
+
+        .target(
+            name: "TypeInformationMetadata",
+            dependencies: [
+                .product(name: "MetadataSystem", package: "MetadataSystem")
+            ]
+        ),
+
         .testTarget(
             name: "ApodiniTypeInformationTests",
             dependencies: [

--- a/Sources/ApodiniTypeInformation/Builder/InstanceCreator.swift
+++ b/Sources/ApodiniTypeInformation/Builder/InstanceCreator.swift
@@ -53,8 +53,6 @@ struct InstanceCreator {
             try handleOptional(on: $0)
             try handlePropertyWrapper(on: $0)
             try handleFluentProperty(on: $0)
-
-            // TODO we need to recurse into the types to
         }
     }
     

--- a/Sources/ApodiniTypeInformation/EnumCase.swift
+++ b/Sources/ApodiniTypeInformation/EnumCase.swift
@@ -8,19 +8,6 @@
 
 import Foundation
 
-/// Represents distinct cases of raw value types of an enumeration
-public enum RawValueType: String, Hashable, Codable, CustomStringConvertible {
-    /// An integer raw value type
-    case int
-    /// A string raw value type
-    case string
-    
-    /// Textual representation of `self`
-    public var description: String {
-        rawValue.upperFirst
-    }
-}
-
 /// Represents a case of an enumeration
 public struct EnumCase: TypeInformationElement {
     /// Name of the case

--- a/Sources/ApodiniTypeInformation/Exports.swift
+++ b/Sources/ApodiniTypeInformation/Exports.swift
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_exported import TypeInformationMetadata

--- a/Sources/ApodiniTypeInformation/Extensions/Collection+Extensions.swift
+++ b/Sources/ApodiniTypeInformation/Extensions/Collection+Extensions.swift
@@ -47,7 +47,7 @@ extension Array where Element: TypeInformationElement {
         return mutableLhs
     }
 
-    /// Appends lhs to rhs TODO operate precedence is pretty unintuitive!!
+    /// Appends lhs to rhs
     static func + (lhs: Element, rhs: Self) -> Self {
         rhs + lhs
     }

--- a/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ApodiniContext
 
 public extension TypeInformation {
     /// A simplified enum of the `typeInformation`
@@ -141,8 +142,8 @@ public extension TypeInformation {
         case let .repeated(element): return element.unwrapped.typeName
         case let .dictionary(_, value): return value.unwrapped.typeName
         case let .optional(wrappedValue): return wrappedValue.unwrapped.typeName
-        case let .enum(name, _, _): return name
-        case let .object(name, _): return name
+        case let .enum(name, _, _, _): return name
+        case let .object(name, _, _): return name
         case let .reference(referenceKey): return .init(name: referenceKey.rawValue)
         }
     }
@@ -201,14 +202,14 @@ public extension TypeInformation {
     /// Returns object properties if `self` is `.object`, otherwise an empty array
     var objectProperties: [TypeProperty] {
         switch self {
-        case let .object(_, properties): return properties
+        case let .object(_, properties, _): return properties
         default: return objectType?.objectProperties ?? []
         }
     }
     
     /// Returns enum cases if `self` is `.enum`, otherwise an empty array
     var enumCases: [EnumCase] {
-        if case let .enum(_, _, cases) = self {
+        if case let .enum(_, _, cases, _) = self {
             return cases
         }
         return []
@@ -216,7 +217,7 @@ public extension TypeInformation {
     
     /// Return rawValueType type if `self` is enum
     var rawValueType: RawValueType? {
-        if case let .enum(_, rawValueType, _) = self {
+        if case let .enum(_, rawValueType, _, _) = self {
             return rawValueType
         }
         return nil
@@ -225,6 +226,17 @@ public extension TypeInformation {
     /// Wrapps a type descriptor as an optional type. If already an optional, returns self
     var asOptional: TypeInformation {
         isOptional ? self : .optional(wrappedValue: self)
+    }
+
+    var context: Context? {
+        switch self {
+        case let .object(_, _, context):
+            return context
+        case let .enum(_, _, _, context):
+            return context
+        default:
+            return nil
+        }
     }
     
     /// Recursively returns all types included in this `typeInformation`, e.g. primitive types, enums, objects
@@ -238,7 +250,7 @@ public extension TypeInformation {
             allTypes += .scalar(key) + value.allTypes()
         case let .optional(wrappedValue):
             allTypes += wrappedValue.allTypes()
-        case let .object(_, properties):
+        case let .object(_, properties, _):
             allTypes += properties.flatMap { $0.type.allTypes() }
         default: break
         }
@@ -294,10 +306,11 @@ public extension TypeInformation {
             return .dictionary(key: key, value: value.referencedProperties())
         case let .optional(wrappedValue):
             return .optional(wrappedValue: wrappedValue.referencedProperties())
-        case let .object(typeName, properties):
+        case let .object(typeName, properties, context):
             return .object(
                 name: typeName,
-                properties: properties.map { $0.referencedType() }
+                properties: properties.map { $0.referencedType() },
+                context: context
             )
         case .reference: fatalError("Attempted to reference a reference")
         }
@@ -334,8 +347,8 @@ public extension TypeInformation {
     }
     
     /// Returns an enum with string raw value with the given name and cases
-    static func `enum`(name: TypeName, cases: [EnumCase]) -> TypeInformation {
-        .enum(name: name, rawValueType: .string, cases: cases)
+    static func `enum`(name: TypeName, cases: [EnumCase], context: Context) -> TypeInformation {
+        .enum(name: name, rawValueType: .string, cases: cases, context: context)
     }
 
     /// Returns a reference with the given string key

--- a/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
@@ -215,8 +215,8 @@ public extension TypeInformation {
         return []
     }
     
-    /// Return rawValueType type if `self` is enum
-    var rawValueType: RawValueType? {
+    /// Return rawValueType type if `self` is enum and enum has a raw value type.
+    var rawValueType: TypeInformation? {
         if case let .enum(_, rawValueType, _, _) = self {
             return rawValueType
         }
@@ -346,11 +346,6 @@ public extension TypeInformation {
     /// Returns all distinct objects in `allTypes()`
     func objectTypes() -> [TypeInformation] {
         filter(\.isObject)
-    }
-    
-    /// Returns an enum with string raw value with the given name and cases
-    static func `enum`(name: TypeName, cases: [EnumCase], context: Context = .init()) -> TypeInformation {
-        .enum(name: name, rawValueType: .string, cases: cases, context: context)
     }
 
     /// Returns a reference with the given string key

--- a/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
@@ -349,7 +349,7 @@ public extension TypeInformation {
     }
     
     /// Returns an enum with string raw value with the given name and cases
-    static func `enum`(name: TypeName, cases: [EnumCase], context: Context) -> TypeInformation {
+    static func `enum`(name: TypeName, cases: [EnumCase], context: Context = .init()) -> TypeInformation {
         .enum(name: name, rawValueType: .string, cases: cases, context: context)
     }
 

--- a/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
@@ -228,6 +228,8 @@ public extension TypeInformation {
         isOptional ? self : .optional(wrappedValue: self)
     }
 
+    /// Retrieves the `Context` where parsed Metadata is stored of a ``TypeInformation`` instance.
+    /// Returns nil for cases of ``TypeInformation`` which don't expose Metadata declaration blocks.
     var context: Context? {
         switch self {
         case let .object(_, _, context):

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -25,7 +25,7 @@ public enum TypeInformation: TypeInformationElement {
     /// An object type with properties containing a `TypeInformation` and a name.
     /// The `Context` captures any Metadata Declarations, if the analyzed type provides
     /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
-    case object(name: TypeName, properties: [TypeProperty], context: Context = init())
+    case object(name: TypeName, properties: [TypeProperty], context: Context = .init())
     /// A reference to a type information instance
     case reference(ReferenceKey)
 }

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -21,11 +21,11 @@ public enum TypeInformation: TypeInformationElement {
     /// An enum type with `String` cases.
     /// The `Context` captures any Metadata Declarations, if the analyzed type provides
     /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
-    case `enum`(name: TypeName, rawValueType: RawValueType, cases: [EnumCase], context: Context)
+    case `enum`(name: TypeName, rawValueType: RawValueType, cases: [EnumCase], context: Context = .init())
     /// An object type with properties containing a `TypeInformation` and a name.
     /// The `Context` captures any Metadata Declarations, if the analyzed type provides
     /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
-    case object(name: TypeName, properties: [TypeProperty], context: Context)
+    case object(name: TypeName, properties: [TypeProperty], context: Context = init())
     /// A reference to a type information instance
     case reference(ReferenceKey)
 }

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -31,7 +31,7 @@ public enum TypeInformation: TypeInformationElement {
 }
 
 // MARK: - TypeInformation + Equatable + Hashable
-extension TypeInformation {
+extension TypeInformation: Hashable {
     public func hash(into hasher: inout Hasher) {
         switch self {
         case let .scalar(primitiveType):

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -21,7 +21,7 @@ public enum TypeInformation: TypeInformationElement {
     /// An enum type with `String` cases.
     /// The `Context` captures any Metadata Declarations, if the analyzed type provides
     /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
-    case `enum`(name: TypeName, rawValueType: RawValueType, cases: [EnumCase], context: Context = .init())
+    indirect case `enum`(name: TypeName, rawValueType: TypeInformation?, cases: [EnumCase], context: Context = .init())
     /// An object type with properties containing a `TypeInformation` and a name.
     /// The `Context` captures any Metadata Declarations, if the analyzed type provides
     /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
@@ -126,7 +126,7 @@ extension TypeInformation {
         case let .enum(name, rawValue, cases, _):
             var enumContainer = container.nestedContainer(keyedBy: EnumKeys.self, forKey: .enum)
             try enumContainer.encode(name, forKey: .typeName)
-            try enumContainer.encode(rawValue, forKey: .rawValueType)
+            try enumContainer.encodeIfPresent(rawValue, forKey: .rawValueType)
             try enumContainer.encode(cases, forKey: .cases)
         case let .object(name, properties, _):
             var objectContainer = container.nestedContainer(keyedBy: ObjectKeys.self, forKey: .object)
@@ -154,7 +154,7 @@ extension TypeInformation {
         case .enum:
             let enumContainer = try container.nestedContainer(keyedBy: EnumKeys.self, forKey: .enum)
             let name = try enumContainer.decode(TypeName.self, forKey: .typeName)
-            let rawValueType = try enumContainer.decode(RawValueType.self, forKey: .rawValueType)
+            let rawValueType = try enumContainer.decodeIfPresent(TypeInformation.self, forKey: .rawValueType)
             let cases = try enumContainer.decode([EnumCase].self, forKey: .cases)
             self = .enum(name: name, rawValueType: rawValueType, cases: cases, context: .init())
         case .object:

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MetadataSystem
 
 public enum TypeInformation: TypeInformationElement {
     /// A scalar type
@@ -17,16 +18,52 @@ public enum TypeInformation: TypeInformationElement {
     indirect case dictionary(key: PrimitiveType, value: TypeInformation)
     /// An optional type with `TypeInformation` wrapped values
     indirect case optional(wrappedValue: TypeInformation)
-    /// An enum type with `String` cases
-    case `enum`(name: TypeName, rawValueType: RawValueType, cases: [EnumCase])
-    /// An object type with properties containing a `TypeInformation` and a name
-    case object(name: TypeName, properties: [TypeProperty])
+    /// An enum type with `String` cases.
+    /// The `Context` captures any Metadata Declarations, if the analyzed type provides
+    /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
+    case `enum`(name: TypeName, rawValueType: RawValueType, cases: [EnumCase], context: Context)
+    /// An object type with properties containing a `TypeInformation` and a name.
+    /// The `Context` captures any Metadata Declarations, if the analyzed type provides
+    /// Metadata Declarations by conforming to `StaticContentMetadataBlock`.
+    case object(name: TypeName, properties: [TypeProperty], context: Context)
     /// A reference to a type information instance
     case reference(ReferenceKey)
 }
 
-// MARK: - TypeInformation + Equatable
+// MARK: - TypeInformation + Equatable + Hashable
 extension TypeInformation {
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case let .scalar(primitiveType):
+            hasher.combine(0)
+            hasher.combine(primitiveType)
+        case let .repeated(element):
+            hasher.combine(1)
+            hasher.combine(element)
+        case let .dictionary(key, value):
+            hasher.combine(2)
+            hasher.combine(key)
+            hasher.combine(value)
+        case let .optional(wrappedValue):
+            hasher.combine(3)
+            hasher.combine(wrappedValue)
+        case let .enum(name, rawValueType, cases, _):
+            hasher.combine(4)
+            hasher.combine(name)
+            hasher.combine(rawValueType)
+            hasher.combine(cases)
+            // context is not considered for hashing
+        case let .object(name, properties, _):
+            hasher.combine(5)
+            hasher.combine(name)
+            hasher.combine(properties)
+            // context is not considered for hashing
+        case let .reference(referenceKey):
+            hasher.combine(6)
+            hasher.combine(referenceKey)
+        }
+    }
+
     /// Returns with lhs is equal to rhs
     public static func == (lhs: TypeInformation, rhs: TypeInformation) -> Bool {
         if !lhs.sameType(with: rhs) {
@@ -42,9 +79,9 @@ extension TypeInformation {
             return lhsKey == rhsKey && lhsValue == rhsValue
         case let (.optional(lhsWrappedValue), .optional(rhsWrappedValue)):
             return lhsWrappedValue == rhsWrappedValue
-        case let (.enum(lhsName, lhsRawValue, lhsCases), .enum(rhsName, rhsRawValue, rhsCases)):
+        case let (.enum(lhsName, lhsRawValue, lhsCases, _), .enum(rhsName, rhsRawValue, rhsCases, _)):
             return lhsName == rhsName && lhsRawValue == rhsRawValue && lhsCases.equalsIgnoringOrder(to: rhsCases)
-        case let (.object(lhsName, lhsProperties), .object(rhsName, rhsProperties)):
+        case let (.object(lhsName, lhsProperties, _), .object(rhsName, rhsProperties, _)):
             return lhsName == rhsName && lhsProperties.equalsIgnoringOrder(to: rhsProperties)
         case let (.reference(lhsKey), .reference(rhsKey)):
             return lhsKey == rhsKey
@@ -86,12 +123,12 @@ extension TypeInformation {
             try dictionaryContainer.encode(key, forKey: .key)
             try dictionaryContainer.encode(value, forKey: .value)
         case let .optional(wrappedValue): try container.encode(wrappedValue, forKey: .optional)
-        case let .enum(name, rawValue, cases):
+        case let .enum(name, rawValue, cases, _):
             var enumContainer = container.nestedContainer(keyedBy: EnumKeys.self, forKey: .enum)
             try enumContainer.encode(name, forKey: .typeName)
             try enumContainer.encode(rawValue, forKey: .rawValueType)
             try enumContainer.encode(cases, forKey: .cases)
-        case let .object(name, properties):
+        case let .object(name, properties, _):
             var objectContainer = container.nestedContainer(keyedBy: ObjectKeys.self, forKey: .object)
             try objectContainer.encode(name, forKey: .typeName)
             try objectContainer.encodeIfNotEmpty(properties, forKey: .properties)
@@ -119,12 +156,13 @@ extension TypeInformation {
             let name = try enumContainer.decode(TypeName.self, forKey: .typeName)
             let rawValueType = try enumContainer.decode(RawValueType.self, forKey: .rawValueType)
             let cases = try enumContainer.decode([EnumCase].self, forKey: .cases)
-            self = .enum(name: name, rawValueType: rawValueType, cases: cases)
+            self = .enum(name: name, rawValueType: rawValueType, cases: cases, context: .init())
         case .object:
             let objectContainer = try container.nestedContainer(keyedBy: ObjectKeys.self, forKey: .object)
             self = .object(
                 name: try objectContainer.decode(TypeName.self, forKey: .typeName),
-                properties: try objectContainer.decodeIfPresentOrInitEmpty([TypeProperty].self, forKey: .properties)
+                properties: try objectContainer.decodeIfPresentOrInitEmpty([TypeProperty].self, forKey: .properties),
+                context: .init()
             )
         case .reference: self = .reference(try container.decode(ReferenceKey.self, forKey: .reference))
         default: throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Failed to decode TypeInformation"))

--- a/Sources/ApodiniTypeInformation/TypesStore.swift
+++ b/Sources/ApodiniTypeInformation/TypesStore.swift
@@ -39,7 +39,7 @@ public struct TypesStore {
             let referencedProperties = objectType.objectProperties.map { property -> TypeProperty in
                 .init(name: property.name, type: store(property.type), annotation: property.annotation) // storing potentially referencable properties
             }
-            storage[key.rawValue] = .object(name: objectType.typeName, properties: referencedProperties)
+            storage[key.rawValue] = .object(name: objectType.typeName, properties: referencedProperties, context: objectType.context ?? .init())
         }
         
         return type.asReference(with: key) // referencing the type
@@ -52,7 +52,7 @@ public struct TypesStore {
         }
         
         /// If the stored type is an object, we recursively construct its properties and update the stored
-        if case let .object(name, properties) = stored {
+        if case let .object(name, properties, context) = stored {
             let newProperties = properties.map { property -> TypeProperty in
                 if let propertyReference = property.type.reference {
                     return .init(
@@ -63,7 +63,7 @@ public struct TypesStore {
                 }
                 return property
             }
-            stored = .object(name: name, properties: newProperties)
+            stored = .object(name: name, properties: newProperties, context: context)
         }
         
         switch reference {

--- a/Sources/TypeInformationMetadata/AnyMetadata+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/AnyMetadata+TypeInformation.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+/// `ContentMetadata` represents arbitrary Metadata that can be declared on `Content` types.
+public protocol AnyContentMetadata: AnyMetadata {}

--- a/Sources/TypeInformationMetadata/BuiltinMetadata/EmptyMetadata.swift
+++ b/Sources/TypeInformationMetadata/BuiltinMetadata/EmptyMetadata.swift
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+extension ContentMetadataNamespace {
+    /// Name definition for the `EmptyContentMetadata`
+    public typealias Empty = EmptyContentMetadata
+}
+
+/// `EmptyContentMetadata` is a `AnyContentMetadata` which in fact doesn't hold any Metadata.
+/// The Metadata is available under the `ContentMetadataNamespace.Empty` name and can be used like the following:
+/// ```swift
+/// struct ExampleContent: Content {
+///     // ...
+///     var metadata: Metadata {
+///         Empty()
+///     }
+/// }
+/// ```
+public struct EmptyContentMetadata: EmptyMetadata, ContentMetadataDefinition {
+    public init() {}
+}

--- a/Sources/TypeInformationMetadata/Exports.swift
+++ b/Sources/TypeInformationMetadata/Exports.swift
@@ -1,0 +1,9 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+@_exported import MetadataSystem

--- a/Sources/TypeInformationMetadata/InternalMetadata/ArrayMetadata+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/InternalMetadata/ArrayMetadata+TypeInformation.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+struct AnyContentMetadataArray: AnyMetadataArray, AnyContentMetadata {
+    let array: [AnyContentMetadata]
+
+    init(_ array: [AnyContentMetadata]) {
+        self.array = array
+    }
+}

--- a/Sources/TypeInformationMetadata/InternalMetadata/WrappedMetadata+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/InternalMetadata/WrappedMetadata+TypeInformation.swift
@@ -1,0 +1,17 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+struct WrappedContentMetadataDefinition<Metadata: ContentMetadataDefinition>: WrappedMetadataDefinition, AnyContentMetadata {
+    let metadata: Metadata
+
+    init(_ metadata: Metadata) {
+        self.metadata = metadata
+    }
+}

--- a/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
@@ -1,3 +1,11 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
 import MetadataSystem
 
 public protocol AnyContentMetadataBlock: AnyMetadataBlock, AnyContentMetadata, ContentMetadataNamespace {}

--- a/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
@@ -15,10 +15,16 @@ public protocol AnyStaticContentMetadataBlock: AnyContentMetadataBlock {
 }
 
 public extension AnyStaticContentMetadataBlock {
+    /// Type erased metadata content of this block.
     var typeErasedContent: AnyMetadata {
         Self.typeErasedContent
     }
 
+    /// This method accepts the `MetadataParser` in order to parse the Metadata tree.
+    /// The implementation should either forward the visitor to its content (e.g. in the case of a `AnyMetadataBlock`)
+    /// or add the parsed Metadata to the visitor.
+    ///
+    /// - Parameter visitor: The `MetadataParser` parsing the Metadata tree.
     static func collectMetadata(_ visitor: MetadataParser) {
         typeErasedContent.collectMetadata(visitor)
     }
@@ -61,7 +67,7 @@ public protocol ContentMetadataBlock: AnyContentMetadataBlock {
 public extension ContentMetadataBlock {
     /// Returns the type erased metadata content of the ``AnyMetadataBlock``.
     var typeErasedContent: AnyMetadata {
-        self.metadata as! AnyMetadata
+        self.metadata as! AnyMetadata // swiftlint:disable:this force_cast
     }
 }
 
@@ -75,7 +81,7 @@ public protocol StaticContentMetadataBlock: AnyStaticContentMetadataBlock {
 public extension StaticContentMetadataBlock {
     /// Returns the type erased metadata content of the ``AnyMetadataBlock``.
     static var typeErasedContent: AnyMetadata {
-        Self.metadata as! AnyMetadata
+        Self.metadata as! AnyMetadata // swiftlint:disable:this force_cast
     }
 }
 

--- a/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/MetadataBlock+TypeInformation.swift
@@ -1,0 +1,96 @@
+import MetadataSystem
+
+public protocol AnyContentMetadataBlock: AnyMetadataBlock, AnyContentMetadata, ContentMetadataNamespace {}
+
+public protocol AnyStaticContentMetadataBlock: AnyContentMetadataBlock {
+    static var typeErasedContent: AnyMetadata { get }
+}
+
+public extension AnyStaticContentMetadataBlock {
+    var typeErasedContent: AnyMetadata {
+        Self.typeErasedContent
+    }
+
+    static func collectMetadata(_ visitor: MetadataParser) {
+        typeErasedContent.collectMetadata(visitor)
+    }
+}
+
+
+extension ContentMetadataNamespace {
+    /// Name definition for the `StandardContentMetadataBlock`
+    public typealias Block = StandardContentMetadataBlock
+}
+
+/// The `ContentMetadataBlock` protocol represents `AnyMetadataBlock`s which can only contain
+/// `AnyContentMetadata` and itself can only be placed in `AnyContentMetadata` Declaration Blocks.
+///
+/// See `StandardContentMetadataBlock` for a general purpose `ContentMetadataBlock` available by default.
+///
+/// By conforming to `ContentMetadataBlock` you can create reusable Metadata like the following:
+/// ```swift
+/// struct DefaultDescriptionMetadata: ContentMetadataBlock {
+///     var metadata: Metadata {
+///         Description("Example Description")
+///         // ...
+///     }
+/// }
+///
+/// struct ExampleContent: Content {
+///     // ...
+///     static var metadata: Metadata {
+///         DefaultDescriptionMetadata()
+///     }
+/// }
+/// ```
+public protocol ContentMetadataBlock: AnyContentMetadataBlock {
+    associatedtype Metadata = AnyContentMetadata
+
+    @ContentMetadataBuilder
+    var metadata: Metadata { get }
+}
+
+public extension ContentMetadataBlock {
+    /// Returns the type erased metadata content of the ``AnyMetadataBlock``.
+    var typeErasedContent: AnyMetadata {
+        self.metadata as! AnyMetadata
+    }
+}
+
+public protocol StaticContentMetadataBlock: AnyStaticContentMetadataBlock {
+    associatedtype Metadata = AnyContentMetadata
+
+    @ContentMetadataBuilder
+    static var metadata: Metadata { get }
+}
+
+public extension StaticContentMetadataBlock {
+    /// Returns the type erased metadata content of the ``AnyMetadataBlock``.
+    static var typeErasedContent: AnyMetadata {
+        Self.metadata as! AnyMetadata
+    }
+}
+
+
+/// `StandardContentMetadataBlock` is a `ContentMetadataBlock` available by default.
+/// It is available under the `Collect` name in `Content` Metadata Declaration Blocks.
+///
+/// It may be used in `Content` Metadata Declaration Blocks in the following way:
+/// ```swift
+/// struct ExampleContent: Content {
+///     // ...
+///     static var metadata: Metadata {
+///         // ...
+///         Block {
+///             // ...
+///         }
+///     }
+/// }
+/// ```
+public struct StandardContentMetadataBlock: ContentMetadataBlock {
+    public var metadata: AnyContentMetadata
+
+    public init(@ContentMetadataBuilder metadata: () -> AnyContentMetadata) {
+        self.metadata = metadata()
+    }
+}

--- a/Sources/TypeInformationMetadata/MetadataDefinition+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/MetadataDefinition+TypeInformation.swift
@@ -1,0 +1,19 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+/// See `MetadataDefinition` for an explanation on what a Metadata Definition is
+/// and a recommendation for a naming convention.
+///
+/// Any Metadata Definition conforming to `ContentMetadataDefinition` can be used in
+/// the Metadata Declaration Blocks of a `Content` Type to annotate the `Content` Type with
+/// the given Metadata.
+///
+/// Use the `ContentMetadataNamespace` to define the name used in the Metadata DSL.
+public protocol ContentMetadataDefinition: MetadataDefinition, AnyContentMetadata {}

--- a/Sources/TypeInformationMetadata/MetadataNamespace.swift
+++ b/Sources/TypeInformationMetadata/MetadataNamespace.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// The `ContentMetadataNamespace` can be used to define an appropriate
+/// Name for your `ContentMetadataDefinition` in a way that avoids Name collisions
+/// on the global Scope.
+///
+/// Given the example of `DescriptionContentMetadata` you can define a Name like the following:
+/// ```swift
+/// extension ContentMetadataNamespace {
+///     public typealias Description = DescriptionContentMetadata
+/// }
+/// ```
+///
+/// Refer to `TypedContentMetadataNamespace` if you need access to the generic `Content`
+/// Type where the Metadata is used on.
+public protocol ContentMetadataNamespace {}

--- a/Sources/TypeInformationMetadata/RestrictedMetadataBlock+TypeInformation.swift
+++ b/Sources/TypeInformationMetadata/RestrictedMetadataBlock+TypeInformation.swift
@@ -1,0 +1,30 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import MetadataSystem
+
+/// The `RestrictedContentMetadataBlock` protocol represents `RestrictedMetadataBlock`s which can only contain
+/// `AnyContentMetadata` and itself can only be placed in `AnyContentMetadata` Declaration Blocks.
+/// Use the generic type `RestrictedContent` to define which `AnyContentMetadata` is allowed in the Block.
+///
+/// Given a `Example` Metadata (already part of the `ContentMetadataNamespace`), a `RestrictedContentMetadataBlock`
+/// can be added to the Namespace like the following:
+/// ```swift
+/// extension ContentMetadataNamespace {
+///     public typealias Examples = RestrictedContentMetadataBlock<Example>
+/// }
+/// ```
+public struct RestrictedContentMetadataBlock<RestrictedContent: AnyContentMetadata>: ContentMetadataBlock, RestrictedMetadataBlock {
+    public typealias RestrictedContent = RestrictedContent
+
+    public var metadata: AnyContentMetadata
+
+    public init(@RestrictedMetadataBlockBuilder<Self> metadata: () -> AnyContentMetadata) {
+        self.metadata = metadata()
+    }
+}

--- a/Sources/TypeInformationMetadata/ResultBuilder/ContentMetadataBuilder.swift
+++ b/Sources/TypeInformationMetadata/ResultBuilder/ContentMetadataBuilder.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable missing_docs
+
+@resultBuilder
+public enum ContentMetadataBuilder {}
+
+public extension ContentMetadataBuilder {
+    static func buildExpression<Metadata: ContentMetadataDefinition>(_ expression: Metadata) -> AnyContentMetadata {
+        WrappedContentMetadataDefinition(expression)
+    }
+
+    static func buildExpression<Metadata: ContentMetadataBlock>(_ expression: Metadata) -> AnyContentMetadata {
+        expression
+    }
+
+    static func buildOptional(_ component: AnyContentMetadata?) -> AnyContentMetadata {
+        component ?? EmptyContentMetadata()
+    }
+
+    static func buildEither(first: AnyContentMetadata) -> AnyContentMetadata {
+        first
+    }
+
+    static func buildEither(second: AnyContentMetadata) -> AnyContentMetadata {
+        second
+    }
+
+    static func buildArray(_ components: [AnyContentMetadata]) -> AnyContentMetadata {
+        AnyContentMetadataArray(components)
+    }
+
+    static func buildBlock(_ components: AnyContentMetadata...) -> AnyContentMetadata {
+        AnyContentMetadataArray(components)
+    }
+}

--- a/Sources/TypeInformationMetadata/ResultBuilder/RestrictedMetadataBlockBuilder.swift
+++ b/Sources/TypeInformationMetadata/ResultBuilder/RestrictedMetadataBlockBuilder.swift
@@ -45,4 +45,3 @@ public extension RestrictedMetadataBlockBuilder where Block: ContentMetadataBloc
         AnyContentMetadataArray(components)
     }
 }
-

--- a/Sources/TypeInformationMetadata/ResultBuilder/RestrictedMetadataBlockBuilder.swift
+++ b/Sources/TypeInformationMetadata/ResultBuilder/RestrictedMetadataBlockBuilder.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+// swiftlint:disable missing_docs
+
+import MetadataSystem
+
+
+@resultBuilder
+public enum RestrictedMetadataBlockBuilder<Block: RestrictedMetadataBlock> {}
+
+
+// MARK: Restricted Content Metadata Block
+public extension RestrictedMetadataBlockBuilder where Block: ContentMetadataBlock, Block.RestrictedContent: AnyContentMetadata {
+    static func buildExpression(_ expression: Block.RestrictedContent) -> AnyContentMetadata {
+        expression
+    }
+
+    static func buildExpression(_ expression: Block) -> AnyContentMetadata {
+        expression
+    }
+
+    static func buildOptional(_ component: AnyContentMetadata?) -> AnyContentMetadata {
+        component ?? EmptyContentMetadata()
+    }
+
+    static func buildEither(first: AnyContentMetadata) -> AnyContentMetadata {
+        first
+    }
+
+    static func buildEither(second: AnyContentMetadata) -> AnyContentMetadata {
+        second
+    }
+
+    static func buildArray(_ components: [AnyContentMetadata]) -> AnyContentMetadata {
+        AnyContentMetadataArray(components)
+    }
+
+    static func buildBlock(_ components: AnyContentMetadata...) -> AnyContentMetadata {
+        AnyContentMetadataArray(components)
+    }
+}
+

--- a/Tests/ApodiniTypeInformationTests/ContentMetadataTests.swift
+++ b/Tests/ApodiniTypeInformationTests/ContentMetadataTests.swift
@@ -1,0 +1,135 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import TypeInformationMetadata
+@testable import ApodiniTypeInformation
+
+private struct TestIntMetadataContextKey: ContextKey {
+    typealias Value = [Int]
+    static var defaultValue: [Int] = []
+}
+
+
+private extension ContentMetadataNamespace {
+    typealias TestInt = TestIntContentMetadata
+    typealias Ints = RestrictedContentMetadataBlock<TestInt>
+}
+
+
+private struct TestIntContentMetadata: ContentMetadataDefinition {
+    typealias Key = TestIntMetadataContextKey
+
+    var num: Int
+    var value: [Int] {
+        [num]
+    }
+
+    init(_ num: Int) {
+        self.num = num
+    }
+}
+
+
+private struct ReusableTestContentMetadata: ContentMetadataBlock {
+    var metadata: Metadata {
+        TestInt(14)
+        Empty()
+        Block {
+            Empty()
+            TestInt(15)
+        }
+    }
+}
+
+private struct TestMetadataContent: StaticContentMetadataBlock {
+    static var state = true
+
+    static var metadata: Metadata {
+        TestInt(0)
+
+        if state {
+            TestInt(1)
+        }
+
+        Empty()
+
+        Block {
+            TestInt(2)
+
+            if state {
+                TestInt(3)
+            } else {
+                TestInt(4)
+            }
+
+            Empty()
+
+            Block {
+                TestInt(5)
+                Empty()
+            }
+
+            TestInt(6)
+        }
+
+        Ints {
+            if state {
+                Ints {
+                    TestInt(7)
+                }
+                TestInt(8)
+            }
+
+            if state {
+                TestInt(9)
+            } else {
+                TestInt(10)
+            }
+
+            for num in 11...11 {
+                TestInt(num)
+            }
+        }
+
+        for num in 12...13 {
+            TestInt(num)
+        }
+
+        ReusableTestContentMetadata()
+    }
+}
+
+final class ContentMetadataTest: TypeInformationTestCase {
+    static var expectedIntsState: [Int] {
+        [0, 1, 2, 3, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15]
+    }
+
+    static var expectedInts: [Int] {
+        [0, 2, 4, 5, 6, 10, 11, 12, 13, 14, 15]
+    }
+
+    func testContentMetadataTrue() {
+        TestMetadataContent.state = true
+
+        let context = TypeInformation.parseMetadata(for: TestMetadataContent.self)
+
+        let capturedInts = context.get(valueFor: TestIntMetadataContextKey.self)
+        let expectedInts: [Int] = Self.expectedIntsState
+        XCTAssertEqual(capturedInts, expectedInts)
+    }
+
+    func testContentMetadataFalse() {
+        TestMetadataContent.state = false
+        let context = TypeInformation.parseMetadata(for: TestMetadataContent.self)
+
+        let captured = context.get(valueFor: TestIntMetadataContextKey.self)
+        let expected: [Int] = Self.expectedInts
+        XCTAssertEqual(captured, expected)
+    }
+}

--- a/Tests/ApodiniTypeInformationTests/InstanceCreatorTests.swift
+++ b/Tests/ApodiniTypeInformationTests/InstanceCreatorTests.swift
@@ -56,7 +56,6 @@ final class InstanceCreatorTests: TypeInformationTestCase {
         student.shop.directions[UUID()] = 0
 
         let studentJSON = try student.toJSON(outputFormatting: [.prettyPrinted])
-        print(try studentJSON.string())
 
         let studentFromJSON = try TestTypes.Student.fromJSON(studentJSON)
         XCTAssertEqual(student, studentFromJSON)

--- a/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
@@ -1,0 +1,87 @@
+//
+// Created by Andreas Bauer on 27.08.21.
+//
+
+import XCTest
+import TypeInformationMetadata
+@testable import ApodiniTypeInformation
+
+private struct DescriptionContextKey: OptionalContextKey {
+    typealias Value = String
+}
+
+private extension ContentMetadataNamespace {
+    typealias Description = DescriptionMetadata
+}
+
+private struct DescriptionMetadata: ContentMetadataDefinition {
+    typealias Key = DescriptionContextKey
+
+    let value: String
+
+    init(_ description: String) {
+        self.value = description
+    }
+}
+
+final class TypeInformationMetadataTests: TypeInformationTestCase {
+    struct SomeType: StaticContentMetadataBlock {
+        var id: String
+
+        var name: String
+
+        var subType: SubType
+
+        static var metadata: Metadata {
+            Description("This is a Description!")
+        }
+    }
+
+    struct SubType: StaticContentMetadataBlock {
+        var someValue: String
+
+        static var metadata: Metadata {
+            Description("This is a sub Description!")
+        }
+    }
+
+    func testContentMetadata() throws {
+        let info = try TypeInformation.of(SomeType.self, with: RuntimeBuilder.self)
+
+        guard case let .object(name, properties, context) = info else {
+            XCTFail("Expected an .object received '\(info)'")
+            return
+        }
+
+        XCTAssertEqual(name.name, "TypeInformationMetadataTestsSomeType")
+        XCTAssertEqual(name.definedIn, "ApodiniTypeInformationTests")
+        XCTAssertEqual(name.genericTypeNames, [])
+
+        XCTAssertEqual(context.get(valueFor: DescriptionMetadata.self), "This is a Description!")
+
+        for property in properties {
+            switch property.name {
+            case "id":
+                XCTAssertEqual(property.type, .scalar(.string))
+            case "name":
+                XCTAssertEqual(property.type, .scalar(.string))
+            case "subType":
+                guard case let .object(name, properties, context) = property.type else {
+                    XCTFail("Unexpected property type \(property)")
+                    return
+                }
+
+                XCTAssertEqual(name.name, "TypeInformationMetadataTestsSubType")
+                XCTAssertEqual(name.definedIn, "ApodiniTypeInformationTests")
+                XCTAssertEqual(name.genericTypeNames, [])
+
+                XCTAssertEqual(context.get(valueFor: DescriptionMetadata.self), "This is a sub Description!")
+
+                XCTAssertEqual(properties.count, 1)
+                XCTAssertEqual(properties[0].type, .scalar(.string))
+            default:
+                XCTFail("Encountered unexpected property type: \(property)")
+            }
+        }
+    }
+}

--- a/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
@@ -1,5 +1,9 @@
 //
-// Created by Andreas Bauer on 27.08.21.
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
 //
 
 import XCTest

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -56,6 +56,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssert(direction.isEnum)
         XCTAssert(user.contains(direction))
         XCTAssert(direction.isContained(in: user))
+        XCTAssertEqual(direction.rawValueType, .scalar(.string))
         
         XCTAssert(!user.sameType(with: direction))
 


### PR DESCRIPTION


<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2021 Paul Schmiedmayer and the project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add support for declaring and parsing Metadata in the TypeInformation framework

## :recycle: Current situation & Problem

Currently, the Apodini framework only exposed very limited support for declaring Metadata on `Content` types.
It was only possible to declare them directly on the return type. Metadata declared on properties of the return type weren't considered.

## :bulb: Proposed solution

This PR integrates the Metadata system directly into the TypeInformation framework, introducing the separate traget `TypeInformationMetadata` for the Metadata frontend.
This allows e.g. an OpenAPI exporter to use Metadata to improve the coverage of the JSON scheme.
Further, the Metadata system could be used in the future for the TypeInformation framework itself to e.g. specify type descriptions.

## :gear: Release Notes 
Added Content Metadata to the TypeInformation framework.

## :heavy_plus_sign: Additional Information

### Related PRs
-- 

### Testing
Further testing was added.

### Reviewer Nudging
--