### PR TITLE
Fix TypeNames on reference types, improve TypeStore and refactor TypeName

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Enter your repository-specific configuration
 
 # ApodiniTypeInformation
 
-[![REUSE Compliance Check](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/reuseaction.yml/badge.svg)](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/reuseaction.yml)
-[![Build and Test](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/build-and-test.yml)
+[![Build](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/build.yml/badge.svg)](https://github.com/Apodini/ApodiniTypeInformation/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/Apodini/ApodiniTypeInformation/branch/develop/graph/badge.svg?token=5MMKMPO5NR)](https://codecov.io/gh/Apodini/ApodiniTypeInformation)
 
 This package contains the implementation of a recurisive enum-based `TypeInformation`:

--- a/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
+++ b/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
@@ -140,7 +140,7 @@ extension TypeInformation {
         let idType = propertyTypeInfo.genericTypes[1]
         
         let customIDObject: TypeInformation = .object(
-            name: .init(name: String(describing: nestedPropertyType) + "ID"),
+            name: .init(rawValue: String(describing: nestedPropertyType) + "ID"),
             properties: [.init(name: "id", type: .optional(wrappedValue: try .init(for: idType)))],
             context: parseMetadata(for: nestedPropertyType)
         )

--- a/Sources/ApodiniTypeInformation/PrimitiveType.swift
+++ b/Sources/ApodiniTypeInformation/PrimitiveType.swift
@@ -162,8 +162,8 @@ public enum PrimitiveType: String, RawRepresentable, CaseIterable, TypeInformati
     /// Creates a new instance by decoding from the given decoder.
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let pritimitiveType = Self(rawValue: try container.decode(String.self).lowercased()) {
-            self = pritimitiveType
+        if let primitiveType = Self(rawValue: try container.decode(String.self).lowercased()) {
+            self = primitiveType
         } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to decode \(Self.self)")
         }

--- a/Sources/ApodiniTypeInformation/ReferenceKey.swift
+++ b/Sources/ApodiniTypeInformation/ReferenceKey.swift
@@ -24,8 +24,6 @@ public struct ReferenceKey: RawRepresentable, TypeInformationElement {
     }
 }
 
-/*
-
 // MARK: - Hashable
 extension ReferenceKey: Hashable {
     public func hash(into hasher: inout Hasher) {
@@ -44,7 +42,7 @@ extension ReferenceKey: Equatable {
 extension ReferenceKey: Codable {
     /// Creates a new instance by decoding from the given decoder.
     public init(from decoder: Decoder) throws {
-        rawValue = try decoder.singleValueContainer().decode(String.self)
+        try rawValue = decoder.singleValueContainer().decode(String.self)
     }
 
     /// Encodes self into the given encoder.
@@ -53,4 +51,3 @@ extension ReferenceKey: Codable {
         try container.encode(rawValue)
     }
 }
- */

--- a/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation+Convenience.swift
@@ -144,7 +144,7 @@ public extension TypeInformation {
         case let .optional(wrappedValue): return wrappedValue.unwrapped.typeName
         case let .enum(name, _, _, _): return name
         case let .object(name, _, _): return name
-        case let .reference(referenceKey): return .init(name: referenceKey.rawValue)
+        case let .reference(referenceKey): return .init(rawValue: referenceKey.rawValue)
         }
     }
     
@@ -223,7 +223,7 @@ public extension TypeInformation {
         return nil
     }
     
-    /// Wrapps a type descriptor as an optional type. If already an optional, returns self
+    /// Wraps a type descriptor as an optional type. If already an optional, returns self
     var asOptional: TypeInformation {
         isOptional ? self : .optional(wrappedValue: self)
     }
@@ -288,8 +288,9 @@ public extension TypeInformation {
         case let .optional(wrappedValue):
             return .optional(wrappedValue: wrappedValue.asReference())
         case .enum, .object:
-            return .reference(.init(typeName.name))
-        case .reference: fatalError("Attempted to reference a reference")
+            return .reference(.init(typeName.rawValue))
+        case .reference:
+            fatalError("Attempted to reference a reference")
         }
     }
     

--- a/Sources/ApodiniTypeInformation/TypeInformation.swift
+++ b/Sources/ApodiniTypeInformation/TypeInformation.swift
@@ -66,10 +66,6 @@ extension TypeInformation: Hashable {
 
     /// Returns with lhs is equal to rhs
     public static func == (lhs: TypeInformation, rhs: TypeInformation) -> Bool {
-        if !lhs.sameType(with: rhs) {
-            return false
-        }
-        
         switch (lhs, rhs) {
         case let (.scalar(lhsPrimitiveType), .scalar(rhsPrimitiveType)):
             return lhsPrimitiveType == rhsPrimitiveType

--- a/Sources/ApodiniTypeInformation/TypeName.swift
+++ b/Sources/ApodiniTypeInformation/TypeName.swift
@@ -17,14 +17,6 @@ public struct TypeNameComponent: TypeInformationElement {
         self.name = name
         self.generics = generics
     }
-
-    public var rawValue: String {
-        var result = name
-        if !generics.isEmpty {
-            result += "<\(generics.map { $0.rawValue }.joined(separator: ","))>"
-        }
-        return result
-    }
 }
 
 /// An object that represents names of the types
@@ -241,13 +233,6 @@ private struct LegacyTypeName: Decodable {
                     )
                 }
         )
-    }
-
-    init(definedIn: String?, name: String, nestedTypeNames: [LegacyTypeName], genericTypeNames: [LegacyTypeName]) {
-        self.definedIn = definedIn
-        self.name = name
-        self.nestedTypeNames = nestedTypeNames
-        self.genericTypeNames = genericTypeNames
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/ApodiniTypeInformation/TypesStore.swift
+++ b/Sources/ApodiniTypeInformation/TypesStore.swift
@@ -29,7 +29,7 @@ public struct TypesStore {
             return type
         }
         
-        let key = ReferenceKey(type.typeName.name)
+        let key = ReferenceKey(type.typeName.rawValue)
         
         if let enumType = type.enumType { // retrieving the nested enum
             storage[key.rawValue] = enumType

--- a/Sources/ApodiniTypeInformation/Utilities/TypeNameParser.swift
+++ b/Sources/ApodiniTypeInformation/Utilities/TypeNameParser.swift
@@ -37,7 +37,7 @@ class TypeNameParser {
     /// The resulting string is used as the input for another ``TypeNameParser`` parser.
     private var subParserInput: [Character] = []
     /// Collects all the results of an instantiated sub ``TypeNameParser``.
-    /// Those collect the ``ParsedTypeName`` of all the generic arguments of the currently parsed type name.
+    /// Those collect the ``GenericArgument`` of all the generic arguments of the currently parsed type name.
     private var genericOutput: [ParsedTypeName] = []
 
     /// Captures the current generic argument parsing depth.

--- a/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationMetadataTests.swift
@@ -57,9 +57,9 @@ final class TypeInformationMetadataTests: TypeInformationTestCase {
             return
         }
 
-        XCTAssertEqual(name.name, "SomeType")
+        XCTAssertEqual(name.mangledName, "SomeType")
         XCTAssertEqual(name.definedIn, "ApodiniTypeInformationTests")
-        XCTAssertEqual(name.genericTypeNames, [])
+        XCTAssertEqual(name.generics, [])
 
         XCTAssertEqual(context.get(valueFor: DescriptionMetadata.self), "This is a Description!")
 
@@ -75,9 +75,9 @@ final class TypeInformationMetadataTests: TypeInformationTestCase {
                     return
                 }
 
-                XCTAssertEqual(name.name, "SubType")
+                XCTAssertEqual(name.mangledName, "SubType")
                 XCTAssertEqual(name.definedIn, "ApodiniTypeInformationTests")
-                XCTAssertEqual(name.genericTypeNames, [])
+                XCTAssertEqual(name.generics, [])
 
                 XCTAssertEqual(context.get(valueFor: DescriptionMetadata.self), "This is a sub Description!")
 

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -26,7 +26,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssert(user.property("cars")?.type.dictionaryValue?.isObject == true)
         XCTAssert(user.dictionaryKey == nil)
         XCTAssert(user.dictionaryValue == nil)
-        XCTAssertEqual(user.typeName.absoluteName(), "TestTypesUser")
+        XCTAssertEqual(user.typeName.buildName(), "TestTypesUser")
         XCTAssertEqual(user.property("otherCars")?.type.nestedTypeString, "TestTypesCar")
         XCTAssert(user.property("url")?.type.objectProperties.isEmpty == true)
         XCTAssert(user.enumCases.isEmpty)
@@ -56,7 +56,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssert(direction.isContained(in: user))
         XCTAssertEqual(direction.rawValueType, .scalar(.string))
         
-        XCTAssert(!user.sameType(with: direction))
+        XCTAssert(!user.comparingRootType(with: direction))
 
         let data = try user.toJSON()
         let userFromData = try TypeInformation.fromJSON(data)
@@ -65,7 +65,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         let userReference = user.asReference()
         let directionReference = direction.asReference()
         XCTAssert(userReference.isReference)
-        XCTAssert(userReference.sameType(with: directionReference))
+        XCTAssert(userReference.comparingRootType(with: directionReference))
         XCTAssertNotEqual(userReference, directionReference)
     }
     
@@ -154,23 +154,5 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssertEqual(result, typeInformation)
         // TypesStore only stores complex types and enums
         XCTAssertEqual(store.store(.scalar(.string)), .scalar(.string))
-    }
-
-    func testTypeNameComparisonWithReference() throws {
-        let userInformation = try TypeInformation(type: TestTypes.User.self)
-        let studentInformation = try TypeInformation(type: TestTypes.Student.self)
-
-        let referencedUser = userInformation.asReference()
-        let referencedStudent = studentInformation.asReference()
-
-        XCTAssertNotEqual(userInformation.typeName, studentInformation.typeName)
-
-        XCTAssertEqual(userInformation.typeName, referencedUser.typeName)
-        XCTAssertNotEqual(userInformation.typeName, referencedStudent.typeName)
-
-        XCTAssertNotEqual(studentInformation.typeName, referencedUser.typeName)
-        XCTAssertEqual(studentInformation.typeName, referencedStudent.typeName)
-
-        XCTAssertNotEqual(referencedUser.typeName, referencedStudent.typeName)
     }
 }

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -76,4 +76,160 @@ final class TypeNameParserTests: TypeInformationTestCase {
             ]
         )
     }
+
+    // swiftlint:disable:next function_body_length
+    func testTypeName() throws {
+        let genericTypeName = TypeName(TestTypes.Generic<TestTypes.SomeStruct, Int>.self)
+
+        XCTAssertEqual(genericTypeName.mangledName, "Generic")
+        XCTAssertEqual(genericTypeName.nestedTypes.first?.name, "TestTypes")
+        XCTAssertEqual(genericTypeName.definedIn, "ApodiniTypeInformationTests")
+        XCTAssertEqual(genericTypeName.absoluteName(), "TestTypesGenericOfTestTypesSomeStructAndInt")
+        XCTAssert(genericTypeName.generics.contains(TypeName(Int.self)))
+
+        let string = TypeName(String.self)
+        XCTAssertEqual(string.mangledName, "String")
+        XCTAssertEqual(string.definedIn, "Swift")
+        XCTAssert(string.nestedTypes.isEmpty)
+        XCTAssert(string.generics.isEmpty)
+        XCTAssertEqual(string.mangledName, string.absoluteName())
+
+        let nsdata = TypeName(NSData.self)
+        #if os(macOS)
+        XCTAssertEqual(nsdata.definedIn, nil)
+        XCTAssertEqual(nsdata.mangledName, "NSData")
+        #else
+        XCTAssertEqual(nsdata.definedIn, "Foundation")
+        XCTAssertEqual(nsdata.name, "NSData")
+        #endif
+
+        let nsString = TypeName(NSString.self)
+        #if os(macOS)
+        XCTAssertEqual(nsString.definedIn, nil)
+        XCTAssertEqual(nsString.mangledName, "NSString")
+        #else
+        XCTAssertEqual(nsString.definedIn, "Foundation")
+        XCTAssertEqual(nsString.name, "NSString")
+        #endif
+
+        let nsURL = TypeName(NSURL.self)
+        #if os(macOS)
+        XCTAssertEqual(nsURL.definedIn, nil)
+        XCTAssertEqual(nsURL.mangledName, "NSURL")
+        #else
+        XCTAssertEqual(nsURL.definedIn, "Foundation")
+        XCTAssertEqual(nsURL.name, "NSURL")
+        #endif
+
+        let nsStringCompare = TypeName(NSString.CompareOptions.self)
+        #if os(macOS)
+        XCTAssertEqual(nsStringCompare.definedIn, "__C")
+        XCTAssertEqual(nsStringCompare.mangledName, "NSStringCompareOptions")
+        #else
+        XCTAssertEqual(nsStringCompare.definedIn, "Foundation")
+        XCTAssertEqual(nsStringCompare.nestedTypeNames.count, 1)
+        XCTAssertEqual(nsStringCompare.nestedTypeNames[0].name, "NSString")
+        XCTAssertEqual(nsStringCompare.name, "CompareOptions")
+        #endif
+
+        let jsonEncoder = TypeName(JSONEncoder.self)
+        XCTAssert(jsonEncoder.mangledName == String(describing: JSONEncoder.self))
+        XCTAssert(jsonEncoder.definedIn == "Foundation")
+        XCTAssert(jsonEncoder.nestedTypes.isEmpty)
+        XCTAssert(jsonEncoder.generics.isEmpty)
+
+        let someDictionary = TypeName(Dictionary<Int, String>.self)
+        XCTAssert(someDictionary.mangledName == "Dictionary")
+        XCTAssert(someDictionary.definedIn == "Swift")
+        XCTAssert(someDictionary.nestedTypes.isEmpty)
+        XCTAssert(someDictionary.absoluteName("VON", "UND") == "DictionaryVONIntUNDString")
+        XCTAssert(someDictionary.generics.equalsIgnoringOrder(to: [TypeName(String.self), TypeName(Int.self)]))
+
+        let someOptional = TypeName(UUID?.self)
+        XCTAssert(someOptional.mangledName == "Optional")
+        XCTAssert(someOptional.nestedTypes.isEmpty)
+        XCTAssert(someOptional.generics.contains(TypeName(UUID.self)))
+
+        let someArray = TypeName([Self].self)
+        XCTAssert(someArray.mangledName == "Array")
+        XCTAssert(someArray.absoluteName("PREFIX") == "ArrayPREFIX\(Self.self)")
+        XCTAssert(someArray.nestedTypes.isEmpty)
+        XCTAssert(someArray.generics.first == TypeName(Self.self))
+
+        let null = TypeName(Null.self)
+        XCTAssert(null.mangledName == "Null")
+        XCTAssert(null.definedIn == "ApodiniTypeInformation")
+
+        let innerTypeName = TypeName(TestTypes.Direction.SomeInnerType.self)
+        XCTAssertEqual(innerTypeName.mangledName, "SomeInnerType")
+        XCTAssertEqual(innerTypeName.absoluteName(), "TestTypesDirectionSomeInnerType")
+        XCTAssert(innerTypeName.nestedTypes.equalsIgnoringOrder(to: [TypeNameComponent(name: "TestTypes"), TypeNameComponent(name: "Direction")]))
+    }
+
+    func testLegacyTypeNameDecoding() throws {
+        // describes ApodiniTypeInformationTests.TestTypes.Generic<ApodiniTypeInformationTests.TestTypes.SomeStruct,Swift.String>.Asdf<Swift.Int>
+        let legacyEncodedString = """
+                                  {
+                                      "genericTypeNames" : [
+                                          {
+                                              "name" : "Int",
+                                              "defined-in" : "Swift"
+                                          }
+                                      ],
+                                      "defined-in" : "ApodiniTypeInformationTests",
+                                      "nestedTypeNames" : [
+                                          {
+                                              "name" : "TestTypes",
+                                              "defined-in" : "ApodiniTypeInformationTests"
+                                          },
+                                          {
+                                              "genericTypeNames" : [
+                                                  {
+                                                      "name" : "SomeStruct",
+                                                      "defined-in" : "ApodiniTypeInformationTests",
+                                                      "nestedTypeNames" : [
+                                                          {
+                                                              "name" : "TestTypes",
+                                                              "defined-in" : "ApodiniTypeInformationTests"
+                                                          }
+                                                      ]
+                                                  },
+                                                  {
+                                                      "name" : "String",
+                                                      "defined-in" : "Swift"
+                                                  }
+                                              ],
+                                              "defined-in" : "ApodiniTypeInformationTests",
+                                              "nestedTypeNames" : [
+                                                  {
+                                                      "name" : "TestTypes",
+                                                      "defined-in" : "ApodiniTypeInformationTests"
+                                                  }
+                                              ],
+                                              "name" : "Generic"
+                                          }
+                                      ],
+                                      "name" : "Asdf"
+                                  }
+                                  """
+
+        let typeName = try JSONDecoder().decode(TypeName.self, from: legacyEncodedString.data(using: .utf8)!)
+
+        XCTAssertEqual(
+            typeName,
+            TypeName(
+                definedIn: "ApodiniTypeInformationTests",
+                rootType: TypeNameComponent(name: "Asdf", generics: [TypeName(definedIn: "Swift", rootType: .init(name: "Int"))]),
+                nestedTypes: [
+                    TypeNameComponent(name: "TestTypes"),
+                    TypeNameComponent(name: "Generic", generics: [
+                        TypeName(definedIn: "ApodiniTypeInformationTests", rootType: .init(name: "SomeStruct"), nestedTypes: [
+                            TypeNameComponent(name: "TestTypes")
+                        ]),
+                        TypeName(definedIn: "Swift", rootType: .init(name: "String"))
+                    ])
+                ]
+            )
+        )
+    }
 }

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -84,7 +84,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(genericTypeName.mangledName, "Generic")
         XCTAssertEqual(genericTypeName.nestedTypes.first?.name, "TestTypes")
         XCTAssertEqual(genericTypeName.definedIn, "ApodiniTypeInformationTests")
-        XCTAssertEqual(genericTypeName.absoluteName(), "TestTypesGenericOfTestTypesSomeStructAndInt")
+        XCTAssertEqual(genericTypeName.buildName(), "TestTypesGenericOfTestTypesSomeStructAndInt")
         XCTAssert(genericTypeName.generics.contains(TypeName(Int.self)))
 
         let string = TypeName(String.self)
@@ -92,7 +92,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(string.definedIn, "Swift")
         XCTAssert(string.nestedTypes.isEmpty)
         XCTAssert(string.generics.isEmpty)
-        XCTAssertEqual(string.mangledName, string.absoluteName())
+        XCTAssertEqual(string.mangledName, string.buildName())
 
         let nsdata = TypeName(NSData.self)
         #if os(macOS)
@@ -142,7 +142,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssert(someDictionary.mangledName == "Dictionary")
         XCTAssert(someDictionary.definedIn == "Swift")
         XCTAssert(someDictionary.nestedTypes.isEmpty)
-        XCTAssert(someDictionary.absoluteName("VON", "UND") == "DictionaryVONIntUNDString")
+        XCTAssert(someDictionary.buildName(genericsStart: "VON", genericsSeparator: "UND") == "DictionaryVONIntUNDString")
         XCTAssert(someDictionary.generics.equalsIgnoringOrder(to: [TypeName(String.self), TypeName(Int.self)]))
 
         let someOptional = TypeName(UUID?.self)
@@ -152,7 +152,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
 
         let someArray = TypeName([Self].self)
         XCTAssert(someArray.mangledName == "Array")
-        XCTAssert(someArray.absoluteName("PREFIX") == "ArrayPREFIX\(Self.self)")
+        XCTAssert(someArray.buildName(genericsStart: "PREFIX") == "ArrayPREFIX\(Self.self)")
         XCTAssert(someArray.nestedTypes.isEmpty)
         XCTAssert(someArray.generics.first == TypeName(Self.self))
 
@@ -162,7 +162,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
 
         let innerTypeName = TypeName(TestTypes.Direction.SomeInnerType.self)
         XCTAssertEqual(innerTypeName.mangledName, "SomeInnerType")
-        XCTAssertEqual(innerTypeName.absoluteName(), "TestTypesDirectionSomeInnerType")
+        XCTAssertEqual(innerTypeName.buildName(), "TestTypesDirectionSomeInnerType")
         XCTAssert(innerTypeName.nestedTypes.equalsIgnoringOrder(to: [TypeNameComponent(name: "TestTypes"), TypeNameComponent(name: "Direction")]))
     }
 

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -100,7 +100,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(nsdata.mangledName, "NSData")
         #else
         XCTAssertEqual(nsdata.definedIn, "Foundation")
-        XCTAssertEqual(nsdata.name, "NSData")
+        XCTAssertEqual(nsdata.mangledName, "NSData")
         #endif
 
         let nsString = TypeName(NSString.self)
@@ -109,7 +109,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(nsString.mangledName, "NSString")
         #else
         XCTAssertEqual(nsString.definedIn, "Foundation")
-        XCTAssertEqual(nsString.name, "NSString")
+        XCTAssertEqual(nsString.mangledName, "NSString")
         #endif
 
         let nsURL = TypeName(NSURL.self)
@@ -118,7 +118,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(nsURL.mangledName, "NSURL")
         #else
         XCTAssertEqual(nsURL.definedIn, "Foundation")
-        XCTAssertEqual(nsURL.name, "NSURL")
+        XCTAssertEqual(nsURL.mangledName, "NSURL")
         #endif
 
         let nsStringCompare = TypeName(NSString.CompareOptions.self)
@@ -127,9 +127,9 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssertEqual(nsStringCompare.mangledName, "NSStringCompareOptions")
         #else
         XCTAssertEqual(nsStringCompare.definedIn, "Foundation")
-        XCTAssertEqual(nsStringCompare.nestedTypeNames.count, 1)
-        XCTAssertEqual(nsStringCompare.nestedTypeNames[0].name, "NSString")
-        XCTAssertEqual(nsStringCompare.name, "CompareOptions")
+        XCTAssertEqual(nsStringCompare.nestedTypes.count, 1)
+        XCTAssertEqual(nsStringCompare.nestedTypes[0].name, "NSString")
+        XCTAssertEqual(nsStringCompare.mangledName, "CompareOptions")
         #endif
 
         let jsonEncoder = TypeName(JSONEncoder.self)

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -166,6 +166,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
         XCTAssert(innerTypeName.nestedTypes.equalsIgnoringOrder(to: [TypeNameComponent(name: "TestTypes"), TypeNameComponent(name: "Direction")]))
     }
 
+    // swiftlint:disable:next function_body_length
     func testLegacyTypeNameDecoding() throws {
         // describes ApodiniTypeInformationTests.TestTypes.Generic<ApodiniTypeInformationTests.TestTypes.SomeStruct,Swift.String>.Asdf<Swift.Int>
         let legacyEncodedString = """
@@ -213,7 +214,7 @@ final class TypeNameParserTests: TypeInformationTestCase {
                                   }
                                   """
 
-        let typeName = try JSONDecoder().decode(TypeName.self, from: legacyEncodedString.data(using: .utf8)!)
+        let typeName = try JSONDecoder().decode(TypeName.self, from: XCTUnwrap(legacyEncodedString.data(using: .utf8)))
 
         XCTAssertEqual(
             typeName,


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix `TypeName`s on `.reference` types, improve `TypeStore` and refactor `TypeName`

## :recycle: Current situation & Problem

Currently, the `typeName` property can be called for any `TypeInformation` case (although the documentation [specified otherwise](https://github.com/Apodini/ApodiniTypeInformation/blob/3171d98b7061ae1492c9ec12b35c717b9e5af310/Sources/ApodiniTypeInformation/TypeInformation%2BConvenience.swift#L138)). This creates the illusion that one can easily compare the typeName of the reference version of a type with the non-referenced version, which is not the case.

Further, due to its recursive definition the `TypeName` structure carries a lot of redundant information which isn't really necessary and just complicates the interface.

The `ReferenceKey` of a `.reference` was constructed just by the top level name and ignored any sort of nested types or generics. This results in the possibility of a `ReferenceKey` collision.

Lastly, the `TypeStore` exposes some code duplication and hasn't exactly a well defined interface.

## :bulb: Proposed solution

This PR addresses the above points as follows:
* `typeName` will now result in a fatalError when called for a `.reference` type
* `TypeName` was refactored to carry less redundant information. Note, that it is still backwards compatible when parsing legacy formatted data.
* The problem of `ReferenceKey` collisions was addresses by creating a more detailed `rawValue` representation. Note, while existing data is still parsable, it isn't compatible when one decides to build upon it. Therefore this PR isn't fully backwards compatible.
* The TypeStore was adjusted to be `Codable` and conform to `Sequence` and `Collection` for easy manipulation. Additionally it was refactored to expose less duplicated code.
* The `ReferenceKey` was adjusted to restore `Hashable` and `Codable` conformance.

## :gear: Release Notes 

See the `Proposed solution` section.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Additional test were added, and some test rearranged.

### Reviewer Nudging
Have a look at `TypeName`, `TypeStore` and the convenience extension for `TypeInformation`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
