### PR TITLE
Make TypeStore more robust + TypeName: Sequence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
     with:
       packagename: ApodiniTypeInformation
-      xcodebuildpostfix: -Package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,13 +15,12 @@ on:
 jobs:
   build_and_test:
     name: Build and Test
-    uses: Apodini/.github/.github/workflows/build-and-test.yml@main
+    uses: Apodini/.github/.github/workflows/build-and-test.yml@v1
     with:
       packagename: ApodiniTypeInformation
-      xcodebuildpostfix: -Package
   reuse_action:
     name: REUSE Compliance Check
-    uses: Apodini/.github/.github/workflows/reuse.yml@main
+    uses: Apodini/.github/.github/workflows/reuse.yml@v1
   swiftlint:
     name: SwiftLint
-    uses: Apodini/.github/.github/workflows/swiftlint.yml@main
+    uses: Apodini/.github/.github/workflows/swiftlint.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@ on:
 jobs:
   docs:
     name: Generate Docs
-    uses: Apodini/.github/.github/workflows/docs.yml@main
+    uses: Apodini/.github/.github/workflows/docs.yml@v1
     with:
       packagename: ApodiniTypeInformation

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,6 +16,6 @@ on:
 jobs:
   spm_update:
     name: Swift Package Update
-    uses: Apodini/.github/.github/workflows/spm-update.yml@main
+    uses: Apodini/.github/.github/workflows/spm-update.yml@v1
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/Sources/ApodiniTypeInformation/TypeName.swift
+++ b/Sources/ApodiniTypeInformation/TypeName.swift
@@ -222,6 +222,19 @@ extension TypeName: Comparable {
     }
 }
 
+// MARK: - Sequence
+extension TypeName: Sequence {
+    public typealias Iterator = Array<TypeNameComponent>.Iterator
+
+    public func makeIterator() -> Iterator {
+        var components: [TypeNameComponent] = nestedTypes
+        components.append(TypeNameComponent(name: mangledName, generics: generics))
+
+        return components.makeIterator()
+    }
+}
+
+
 private struct LegacyTypeName: Decodable {
     private enum CodingKeys: String, CodingKey {
         case definedIn = "defined-in"

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -196,5 +196,12 @@ final class TypeInformationTests: TypeInformationTestCase {
         // swiftlint:disable:next force_unwrapping
         let typeStore0 = try decoder.decode(TypesStore.self, from: reencoded.data(using: .utf8)!)
         XCTAssertEqual(typeStore, typeStore0)
+
+        for (key, type) in typeStore {
+            XCTAssertEqual(key, ReferenceKey("CategoryStatus"))
+            XCTAssertEqual(type.isEnum, true)
+            XCTAssertEqual(type.enumCases.count, 2)
+            XCTAssertEqual(type.rawValueType, .scalar(.string))
+        }
     }
 }

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -148,9 +148,10 @@ final class TypeInformationTests: TypeInformationTestCase {
         var store = TypesStore()
         
         let reference = store.store(typeInformation) // storing and retrieving a reference
+        XCTAssert(reference.reference != nil)
 
         let result = store.construct(from: reference) // reconstructing type from the reference
-        
+
         XCTAssertEqual(result, typeInformation)
         // TypesStore only stores complex types and enums
         XCTAssertEqual(store.store(.scalar(.string)), .scalar(.string))

--- a/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeNameParserTests.swift
@@ -10,6 +10,21 @@ import XCTest
 @testable import ApodiniTypeInformation
 
 final class TypeNameParserTests: TypeInformationTestCase {
+    struct Name {
+        var test: String
+    }
+
+    func testIterator() {
+        let name = TypeName(Name.self)
+
+        var result: String = ""
+        for component in name {
+            result += "." + component.name
+        }
+
+        XCTAssertEqual(result, ".TypeNameParserTests.Name")
+    }
+
     func testSimpleType() {
         XCTAssertEqual(
             TypeNameParser("SomeTarget.TestType1.TestType2").parse(),


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Make TypeStore more robust + TypeName: Sequence

## :recycle: Current situation & Problem
* Currently the `TypeStore` doesn't store or reconstruct types if the `.reference` isn't at the root
* Iteration over all `TypeNameComponents` is pretty verbose.

## :bulb: Proposed solution
* This PR insects the whole type when storing or reconstructing from the TypeStore to ensure that all nested types are stored/reconstructed
* Added Sequence conformance to `TypeName` which iterates over the nested types and the root component

## :gear: Release Notes 
* See `Proposed solution`

## :heavy_plus_sign: Additional Information

### Related PRs

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
