### PR TITLE
Add Context to TypeProperty and EnumCase

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
         "state": {
           "branch": null,
-          "revision": "06cac46a958fdf700054f12f682b5c8f27577c9f",
-          "version": "0.1.1"
+          "revision": "7f0df17075a455dcf8b88b234dfaa295b0df7f27",
+          "version": "0.1.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     ],
     dependencies: [
         runtimeDependency(selecting: .standard),
-        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.0"))
+        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.2"))
     ],
     targets: [
         .target(

--- a/Sources/ApodiniTypeInformation/EnumCase.swift
+++ b/Sources/ApodiniTypeInformation/EnumCase.swift
@@ -14,17 +14,31 @@ public struct EnumCase: TypeInformationElement {
     public let name: String
     /// Raw value of the case
     public let rawValue: String
+    /// Any `Context` information associated with the enum case.
+    public let context: Context
     
     /// Initializes self out of a `name`
     ///  - Note: `rawValue` is set equal to `name`
-    public init(_ name: String) {
+    public init(_ name: String, context: Context = Context()) {
         self.name = name
         self.rawValue = name
+        self.context = context
     }
     
     /// Initializes a new instance
-    public init(_ name: String, rawValue: String) {
+    public init(_ name: String, rawValue: String, context: Context = Context()) {
         self.name = name
         self.rawValue = rawValue
+        self.context = context
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(rawValue)
+    }
+
+    public static func == (lhs: EnumCase, rhs: EnumCase) -> Bool {
+        lhs.name == rhs.name
+            && lhs.rawValue == rhs.rawValue
     }
 }

--- a/Sources/ApodiniTypeInformation/EnumCase.swift
+++ b/Sources/ApodiniTypeInformation/EnumCase.swift
@@ -42,3 +42,19 @@ public struct EnumCase: TypeInformationElement {
             && lhs.rawValue == rhs.rawValue
     }
 }
+
+extension EnumCase: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case rawValue
+        case context
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        name = try container.decode(String.self, forKey: .name)
+        rawValue = try container.decode(String.self, forKey: .rawValue)
+        context = try container.decodeIfPresent(Context.self, forKey: .context) ?? Context()
+    }
+}

--- a/Sources/ApodiniTypeInformation/TypeProperty.swift
+++ b/Sources/ApodiniTypeInformation/TypeProperty.swift
@@ -60,6 +60,15 @@ extension TypeProperty: Codable {
         case annotation
         case context
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        name = try container.decode(String.self, forKey: .name)
+        type = try container.decode(TypeInformation.self, forKey: .type)
+        annotation = try container.decodeIfPresent(String.self, forKey: .annotation)
+        context = try container.decodeIfPresent(Context.self, forKey: .context) ?? Context()
+    }
 }
 
 extension TypeProperty: Hashable {


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add Context to TypeProperty and EnumCase

## :recycle: Current situation & Problem
Currently neither `TypeProperty` nor `EnumCase` have a `Context` to store `ContextKey` (only `.enum` and `.object` have one).

## :bulb: Proposed solution
Add `Context` to properties and enum cases.

## :gear: Release Notes 
* TypeProperties and EnumCases can now carrie `Context` information.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
--

### Reviewer Nudging
---

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
