### PR TITLE
Fix encoding and decoding of TypeInformation Context

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
         "state": {
           "branch": null,
-          "revision": "7f0df17075a455dcf8b88b234dfaa295b0df7f27",
-          "version": "0.1.2"
+          "revision": "30b8886934e49d64130868ac0b89219c35fc5447",
+          "version": "0.1.3"
         }
       },
       {
@@ -26,6 +26,15 @@
           "branch": null,
           "revision": "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
           "version": "2.2.4"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     ],
     dependencies: [
         runtimeDependency(selecting: .standard),
-        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.2"))
+        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.3"))
     ],
     targets: [
         .target(

--- a/Sources/ApodiniTypeInformation/TypeProperty.swift
+++ b/Sources/ApodiniTypeInformation/TypeProperty.swift
@@ -45,6 +45,12 @@ public struct TypeProperty {
         .init(name: name, type: type.asReference(), annotation: annotation)
     }
 
+    /// Creates and stores a `.reference` of the `TypeInformation` into the desired `TypeStore`.
+    /// - Parameter typeStore: The `TypeStore` to contact
+    public mutating func reference(into typeStore: inout TypesStore) {
+        type = typeStore.store(type)
+    }
+
     /// Dereference the `TypeInformation` of the property.
     /// - Parameter typeStore: The `TypeStore` to contact
     public mutating func dereference(from typeStore: TypesStore) {

--- a/Sources/ApodiniTypeInformation/TypesStore.swift
+++ b/Sources/ApodiniTypeInformation/TypesStore.swift
@@ -59,12 +59,10 @@ public struct TypesStore {
                 fatalError("Entered irrecoverable state. ReferenceKey wasn't available after creating type reference!")
             }
 
-            let referencedProperties = properties.map { property in
-                TypeProperty(
-                    name: property.name,
-                    type: store(property.type), // storing potentially referencable properties
-                    annotation: property.annotation
-                )
+            let referencedProperties = properties.map { property -> TypeProperty in
+                var property = property
+                property.reference(into: &self)
+                return property
             }
 
             storage[key] = .object(name: name, properties: referencedProperties, context: context)
@@ -88,12 +86,10 @@ public struct TypesStore {
         case .enum:
             return type
         case let .object(name, properties, context):
-            let dereferencedProperties = properties.map { property in
-                TypeProperty(
-                    name: property.name,
-                    type: construct(from: property.type),
-                    annotation: property.annotation
-                )
+            let dereferencedProperties = properties.map { property -> TypeProperty in
+                var property = property
+                property.dereference(from: self)
+                return property
             }
 
             return .object(name: name, properties: dereferencedProperties, context: context)


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix encoding and decoding of TypeInformation Context

## :recycle: Current situation & Problem

There are currently the following issues:
* `Context` objects of `.enum` and `.object` types are never encoder or decode due to previous implementation. This was simply forgotten in #10 
* The `Context` of `TypeProperties` wouldn't be copied when storing or constructing a type into or from a `TypeStore`
* ContextKey values wouldn't always be encoded as base64 string depending on the encoder configuration (fixed in https://github.com/Apodini/MetadataSystem/pull/4)

## :bulb: Proposed solution
This PR dresses those issues-

## :gear: Release Notes 
* Fixed an issue where the `Context` of `.enum` and `.object` TypeInformation instances wouldn't be encoded
* Fixed an issue where the `Context` of `TypeProperty` would be lost when storing into the `TypeStore`
* Fixed an issue with encoding `Context`

## :heavy_plus_sign: Additional Information

### Related PRs
- https://github.com/Apodini/MetadataSystem/pull/4

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
