### PR TITLE
Preserve the Context of a TypeProperty when calling `referencedType()`

### DIFF
--- a/Sources/ApodiniTypeInformation/TypeProperty.swift
+++ b/Sources/ApodiniTypeInformation/TypeProperty.swift
@@ -42,7 +42,12 @@ public struct TypeProperty {
     
     /// Returns a version of self where the type is a reference
     public func referencedType() -> TypeProperty {
-        .init(name: name, type: type.asReference(), annotation: annotation)
+        .init(
+            name: name,
+            type: type.asReference(),
+            annotation: annotation,
+            context: context
+        )
     }
 
     /// Creates and stores a `.reference` of the `TypeInformation` into the desired `TypeStore`.


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Preserve the Context of a TypeProperty when calling `referencedType()`

## :recycle: Current situation & Problem
Currently there is an issue with `TypeProperty.referencedType()` which doesn't preserve the `Context` of a Property.

## :gear: Release Notes 
* Fixed an issue where the `Context` of a `TypeProperty` would get lost when calling `referencedType()` on the property.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
--

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
