### PR TITLE
Add ability to ignore enum cases with associated values

### DIFF
--- a/Sources/ApodiniTypeInformation/Builder/RuntimeBuilder.swift
+++ b/Sources/ApodiniTypeInformation/Builder/RuntimeBuilder.swift
@@ -16,6 +16,6 @@ public struct RuntimeBuilder: TypeInformationBuilder {
     }
     
     public func build() throws -> TypeInformation {
-        try TypeInformation(type: input) // uses the current approach
+        try TypeInformation(type: input, enumAssociatedValues: .reject) // uses the current approach
     }
 }

--- a/Tests/ApodiniTypeInformationTests/TestTypes.swift
+++ b/Tests/ApodiniTypeInformationTests/TestTypes.swift
@@ -41,6 +41,34 @@ extension TestTypes {
         
         struct SomeInnerType {}
     }
+
+    enum EnumWithAssociatedValues: RawRepresentable, Codable, Hashable {
+        case one
+        case two
+        case three(String)
+
+        init(rawValue: String) {
+            switch rawValue {
+            case "one":
+                self = .one
+            case "two":
+                self = .two
+            default:
+                self = .three(rawValue)
+            }
+        }
+
+        var rawValue: String {
+            switch self {
+            case .one:
+                return "one"
+            case .two:
+                return "two"
+            case let .three(value):
+                return value
+            }
+        }
+    }
     
     struct Car: Codable, Equatable {
         let plateNumber: Int

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -55,7 +55,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssert(user.contains(direction))
         XCTAssert(direction.isContained(in: user))
         XCTAssertEqual(direction.rawValueType, .scalar(.string))
-        
+
         XCTAssert(!user.comparingRootType(with: direction))
 
         let data = try user.toJSON()
@@ -203,5 +203,13 @@ final class TypeInformationTests: TypeInformationTestCase {
             XCTAssertEqual(type.enumCases.count, 2)
             XCTAssertEqual(type.rawValueType, .scalar(.string))
         }
+    }
+
+    func testEnumWithAssociatedValues() throws {
+        let typeInfo = try TypeInformation(type: TestTypes.EnumWithAssociatedValues.self, enumAssociatedValues: .ignore)
+
+        XCTAssert(typeInfo.isEnum)
+        XCTAssertEqual(typeInfo.rawValueType, .scalar(.string))
+        XCTAssertEqual(typeInfo.enumCases.count, 2)
     }
 }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Add ability to ignore enum cases with associated values

## :recycle: Current situation & Problem
Currently, the TypeInformation framework will reject parsing any enums which contain enum cases with associated values.
This is e.g. a problem in the gRPC exporter, where every enum has a fallback case to support parsing unknown enum values.

## :bulb: Proposed solution
This PR adds the ability to ignore enum cases with associated values instead of rejecting the enum completely. In our case this is fine, as the `UNRECOGNIZED` case shouldn't be handled anyway. The new option allows to easily add support for parsing those enum cases.

## :gear: Release Notes 
* Added ability to parse enums with enum cases with associated values by ignoring them.

## :heavy_plus_sign: Additional Information

### Related PRs
- https://github.com/Apodini/ApodiniMigrator/pull/11

### Testing
Additional testing was added.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
