### PR TITLE
Fix enum case construction when setting enumAssociatedValues to `.reject`

### DIFF
--- a/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
+++ b/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
@@ -69,7 +69,7 @@ extension TypeInformation {
 
                 let cases: [EnumCase] = typeInfo
                     .cases
-                    .filter { (enumAssociatedValues == .ignore && $0.payloadType == nil ) }
+                    .filter { (enumAssociatedValues == .ignore ? $0.payloadType == nil : true) }
                     .map { EnumCase($0.name) }
 
                 self = .enum(name: typeInfo.typeName, rawValueType: rawValueType, cases: cases, context: context)

--- a/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
+++ b/Tests/ApodiniTypeInformationTests/TypeInformationTests.swift
@@ -55,6 +55,7 @@ final class TypeInformationTests: TypeInformationTestCase {
         XCTAssert(user.contains(direction))
         XCTAssert(direction.isContained(in: user))
         XCTAssertEqual(direction.rawValueType, .scalar(.string))
+        XCTAssertEqual(direction.enumCases.count, 2)
 
         XCTAssert(!user.comparingRootType(with: direction))
 


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fix enum case construction when setting enumAssociatedValues to `.reject`

## :recycle: Current situation & Problem
This is a hot fix PR due to some regression introduced by myself in #13.

## :gear: Release Notes 
* Fixed an regression introduced via #13  where enum cases may not be parsed.

## :heavy_plus_sign: Additional Information

### Related PRs
- Originally introduced in #13 

### Testing
Regression testing was added.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
