### PR TITLE
Swift 5.7 support: remove AssociatedTypeRequirementsKit dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AssociatedTypeRequirementsKit",
-        "repositoryURL": "https://github.com/nerdsupremacist/AssociatedTypeRequirementsKit.git",
-        "state": {
-          "branch": null,
-          "revision": "2e4c49c21ffb2135f1c99fbfcf2119c9d24f5e8c",
-          "version": "0.3.2"
-        }
-      },
-      {
         "package": "MetadataSystem",
         "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,34 +1,32 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "MetadataSystem",
-        "repositoryURL": "https://github.com/Apodini/MetadataSystem.git",
-        "state": {
-          "branch": null,
-          "revision": "f655813f1953af8d3aaac432dad35f394e7bdf75",
-          "version": "0.1.6"
-        }
-      },
-      {
-        "package": "Runtime",
-        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
-        "state": {
-          "branch": null,
-          "revision": "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
-          "version": "2.2.4"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
-        }
+  "pins" : [
+    {
+      "identity" : "metadatasystem",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Apodini/MetadataSystem.git",
+      "state" : {
+        "revision" : "761c5dbaa9f53293b1109f81d469370b5f5f61e7",
+        "version" : "0.1.7"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "runtime",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/wickwirew/Runtime.git",
+      "state" : {
+        "revision" : "dad03135d7701a4e7b3a4051e75d6b37bd8e178e",
+        "version" : "2.2.4"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
+        "version" : "1.0.2"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 //
 // This source file is part of the Apodini open source project

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
     ],
     dependencies: [
         runtimeDependency(selecting: .standard),
-        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.4"))
+        .package(url: "https://github.com/Apodini/MetadataSystem.git", .upToNextMinor(from: "0.1.7"))
     ],
     targets: [
         .target(

--- a/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
+++ b/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
@@ -200,11 +200,6 @@ extension TypeInformation {
     }
 }
 
-//private struct RawEnumVisitor: RawRepresentableTypeVisitor {
-//    func callAsFunction<T: RawRepresentable>(_ type: T.Type) -> Any.Type {
-//        T.self.RawValue
-//    }
-//}
 
 extension RawRepresentable {
     fileprivate static var underlyingRawValueType: Any.Type {

--- a/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
+++ b/Sources/ApodiniTypeInformation/Init/TypeInformation+Init.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import TypeInformationMetadata
-@_implementationOnly import AssociatedTypeRequirementsVisitor
 
 /// With this enum option you can control how Enum cases with associated values are handled in the TypeInformation representation.
 public enum EnumWithAssociatedValuesHandling {
@@ -59,8 +58,8 @@ extension TypeInformation {
                 }
 
                 let rawValueType: TypeInformation?
-                if let rawValue = RawEnumVisitor()(type) {
-                    rawValueType = try .init(for: rawValue, enumAssociatedValues: enumAssociatedValues)
+                if let rawRepresentableTy = type as? any RawRepresentable.Type {
+                    rawValueType = try .init(for: rawRepresentableTy.underlyingRawValueType, enumAssociatedValues: enumAssociatedValues)
                 } else {
                     rawValueType = nil
                 }
@@ -201,8 +200,14 @@ extension TypeInformation {
     }
 }
 
-private struct RawEnumVisitor: RawRepresentableTypeVisitor {
-    func callAsFunction<T: RawRepresentable>(_ type: T.Type) -> Any.Type {
-        T.self.RawValue
+//private struct RawEnumVisitor: RawRepresentableTypeVisitor {
+//    func callAsFunction<T: RawRepresentable>(_ type: T.Type) -> Any.Type {
+//        T.self.RawValue
+//    }
+//}
+
+extension RawRepresentable {
+    fileprivate static var underlyingRawValueType: Any.Type {
+        Self.RawValue.self
     }
 }


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Swift 5.7 support

## :recycle: Current situation & Problem
The AssociatedTypeRequirementsKit package doesn't seem to work in release builds in Swift 5.7.

## :bulb: Proposed solution
We remove the dependency on the AssociatedTypeRequirementsKit package, and instead uses native Swift casts.

## :gear: Release Notes 
- Internal bug fixes

## :heavy_plus_sign: Additional Information
n/a

### Related PRs
- https://github.com/Apodini/MetadataSystem/pull/8
- https://github.com/Apodini/Apodini/pull/446

### Testing
n/a, no functionality was changed

### Reviewer Nudging
the code diff

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
